### PR TITLE
Omar dev Assignment3

### DIFF
--- a/ex01.exs
+++ b/ex01.exs
@@ -26,11 +26,26 @@ defmodule Ex01 do
         2 is the program well laid out,  appropriately using indentation,
           blank lines, vertical alignment
   """
-  
+
   def counter(value \\ 0) do
+    receive do
+      {:next, from} ->
+        send from, {:next_is, value}
+        counter(value + 1)
+    end
   end
 
-end
+  def new_counter(start_value) do
+    spawn __MODULE__, :counter, [start_value]
+  end
+
+  def next_value(counter_pid) do
+    send counter_pid, {:next, self}
+      receive do
+        {:next_is, value} -> value
+      end
+    end
+  end
 
 ExUnit.start()
 
@@ -41,35 +56,29 @@ defmodule Test do
   # This test assumes you have a function `counter` that can be spawned
   # and which handles the `{:next, from}` message
 
-  # test "basic message interface" do
-  #   count = spawn Ex01, :counter, []
-  #   send count, { :next, self }
-  #   receive do
-  #     { :next_is, value } ->
-  #       assert value == 0
-  #   end
-  # 
-  #   send count, { :next, self }
-  #   receive do
-  #     { :next_is, value } ->
-  #       assert value == 1
-  #   end
-  # end
+  test "basic message interface" do
+    count = spawn Ex01, :counter, []
+    send count, { :next, self }
+    receive do
+      { :next_is, value } ->
+        assert value == 0
+    end
+
+    send count, { :next, self }
+    receive do
+      { :next_is, value } ->
+        assert value == 1
+    end
+  end
 
   # then uncomment this one
   # Now we add two new functions to Ex01 that wrap the use of
   # that counter function, making the overall API cleaner
 
-  # test "higher level API interface" do
-  #   count = Ex01.new_counter(5)
-  #   assert  Ex01.next_value(count) == 5
-  #   assert  Ex01.next_value(count) == 6
-  # end
+  test "higher level API interface" do
+    count = Ex01.new_counter(5)
+    assert  Ex01.next_value(count) == 5
+    assert  Ex01.next_value(count) == 6
+  end
 
 end
-
-
-
-
-
-

--- a/ex01.exs
+++ b/ex01.exs
@@ -1,4 +1,3 @@
-
 defmodule Ex01 do
 
   @moduledoc """

--- a/ex02.exs
+++ b/ex02.exs
@@ -23,7 +23,7 @@ defmodule Test do
         2 is the program well laid out,  appropriately using indentation,
           blank lines, vertical alignment
   """
-  
+
 
   @doc """
   First uncomment this test. Here you will be inserting code
@@ -32,15 +32,15 @@ defmodule Test do
   Replace the placeholders with your code.
   """
 
-  # test "counter using an agent" do
-  #   { :ok, counter } = « your code »
-  # 
-  #   value   = « your code »
-  #   assert value == 0
-  # 
-  #   value   = « your code »
-  #   assert value == 1
-  # end
+  test "counter using an agent" do
+    { :ok, counter } = Agent.start(fn -> 0 end)
+
+    value   = Agent.get_and_update(counter, &{&1, (&1 +1) } )
+    assert value == 0
+
+    value   = Agent.get_and_update(counter, &{&1, (&1 +1) } ) 
+    assert value == 1
+  end
 
   @doc """
   Next, uncomment this test, and add code to the Ex02 module at the
@@ -67,9 +67,3 @@ defmodule Test do
   #   assert Ex02.global_next_value == 2
   # end
 end
-
-
-
-
-
-

--- a/ex02.exs
+++ b/ex02.exs
@@ -2,7 +2,11 @@
 defmodule Ex02 do
 
   def new_counter(start_value \\ 0) do
-    Agent
+    {:ok, counter} = Agent.start_link(fn-> start_value end)
+  end
+
+  def next_value({:ok, counter}) do
+    Agent.get_and_update(counter, &{&1, (&1+1)})
   end
 
 end

--- a/ex02.exs
+++ b/ex02.exs
@@ -1,6 +1,10 @@
 
 defmodule Ex02 do
 
+  def new_counter(start_value \\ 0) do
+    Agent
+  end
+
 end
 
 ExUnit.start()
@@ -38,7 +42,7 @@ defmodule Test do
     value   = Agent.get_and_update(counter, &{&1, (&1 +1) } )
     assert value == 0
 
-    value   = Agent.get_and_update(counter, &{&1, (&1 +1) } ) 
+    value   = Agent.get_and_update(counter, &{&1, (&1 +1) } )
     assert value == 1
   end
 
@@ -47,11 +51,11 @@ defmodule Test do
   top of this file to make those tests run.
   """
 
-  # test "higher level API interface" do
-  #   count = Ex02.new_counter(5)
-  #   assert  Ex02.next_value(count) == 5
-  #   assert  Ex02.next_value(count) == 6
-  # end
+  test "higher level API interface" do
+    count = Ex02.new_counter(5)
+    assert  Ex02.next_value(count) == 5
+    assert  Ex02.next_value(count) == 6
+  end
 
   @doc """
   Last (for this exercise), we'll create a global counter by adding

--- a/ex02.exs
+++ b/ex02.exs
@@ -1,12 +1,22 @@
 
 defmodule Ex02 do
 
+  @counter __MODULE__
+
   def new_counter(start_value \\ 0) do
     {:ok, counter} = Agent.start_link(fn-> start_value end)
   end
 
-  def next_value({:ok, counter}) do
-    Agent.get_and_update(counter, &{&1, (&1+1)})
+  def next_value({ :ok, counter }) do
+    Agent.get_and_update(counter, &{&1, (&1+1) } )
+  end
+
+  def new_global_counter(start_value \\ 0) do
+    {:ok, counter} = Agent.start_link(fn -> start_value end, name: @counter)
+  end
+
+  def global_next_value do
+    Agent.get_and_update(@counter, &{&1, (&1+1) } )
   end
 
 end
@@ -68,10 +78,10 @@ defmodule Test do
   that agent into calls to `global_next_value`?
   """
 
-  # test "global counter" do
-  #   Ex02.new_global_counter
-  #   assert Ex02.global_next_value == 0
-  #   assert Ex02.global_next_value == 1
-  #   assert Ex02.global_next_value == 2
-  # end
+  test "global counter" do
+    Ex02.new_global_counter
+    assert Ex02.global_next_value == 0
+    assert Ex02.global_next_value == 1
+    assert Ex02.global_next_value == 2
+  end
 end

--- a/ex02.exs
+++ b/ex02.exs
@@ -1,7 +1,7 @@
 
 defmodule Ex02 do
 
-  @counter __MODULE__
+  @name __MODULE__
 
   def new_counter(start_value \\ 0) do
     {:ok, counter} = Agent.start_link(fn-> start_value end)
@@ -12,11 +12,11 @@ defmodule Ex02 do
   end
 
   def new_global_counter(start_value \\ 0) do
-    {:ok, counter} = Agent.start_link(fn -> start_value end, name: @counter)
+    {:ok, counter} = Agent.start_link(fn -> start_value end, name: @name)
   end
 
   def global_next_value do
-    Agent.get_and_update(@counter, &{&1, (&1+1) } )
+    Agent.get_and_update(@name, &{&1, (&1+1) } )
   end
 
 end

--- a/ex03.exs
+++ b/ex03.exs
@@ -44,7 +44,7 @@ defmodule Ex03 do
         5	does it produce the correct results on any valid data
 
       Tested
-      if tests are provided as part of the assignment: 	
+      if tests are provided as part of the assignment:
         5	all pass
 
       Aesthetics
@@ -60,7 +60,22 @@ defmodule Ex03 do
   """
 
   def pmap(collection, process_count, function) do
-    « your code here »
+
+    # calculate number of chunks
+    num_chunks = collection |> Enum.count |> div(process_count)
+
+    # split collection into n chunks
+    collection |> Enum.chunk(num_chunks, num_chunks, [])
+
+    # process chunks
+    |> Enum.map(&Task.async(fn -> Enum.map(&1, function) end))
+
+    # wait for all the chunks to get processed
+    |> Enum.map(&Task.await/1)
+
+    # put chunks back together
+    |> Enum.concat
+
   end
 
 end
@@ -96,5 +111,5 @@ defmodule TestEx03 do
     assert result2 == result1
     assert time2 < time1 * 0.8
   end
-  
+
 end


### PR DESCRIPTION
RE: Enum.chunk(num_chunks, num_chunks, [])

According to http://elixir-lang.org/docs/stable/elixir/Enum.html#chunk_by/2, 

chunk(enumerable, count, step, leftover \ nil) step is optional, and defaults to count if not passed.

I tried to do Enum.chunk(num_chunks) but it didn't work.

Any idea why that is?
